### PR TITLE
Fix: Compose function uses id function, that was incorrectly imported

### DIFF
--- a/src/Fp/Functions/Callable/Compose.php
+++ b/src/Fp/Functions/Callable/Compose.php
@@ -7,7 +7,7 @@ namespace Fp\Callable;
 use function Fp\Collection\filterNotNull;
 use function Fp\Collection\fold;
 
-use const Fp\Function\id;
+use const Fp\id;
 
 /**
  * @todo drop suppress


### PR DESCRIPTION
Just a little function import bugfix