### PR TITLE
More generic implementation of assertion memoization for proveTrue

### DIFF
--- a/tests/Static/Functions/Evidence/ProveTrueTest.php
+++ b/tests/Static/Functions/Evidence/ProveTrueTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Static\Functions\Evidence;
 
+use Fp\Functional\Either\Either;
 use Fp\Functional\Option\Option;
 use Tests\PhpBlockTestCase;
 
@@ -40,6 +41,38 @@ final class ProveTrueTest extends PhpBlockTestCase
             ',
             strtr('Option<string>', [
                 'Option' => Option::class,
+            ])
+        );
+
+        $this->assertBlockType(
+        /** @lang InjectablePHP */ '
+                /** @var null|int $number */
+                $number = 0;
+
+                $result = Fp\Functional\Either\Either::do(function() use ($number) {
+                    yield Fp\Evidence\proveTrue(null !== $number)->toRight(fn() => "not_number");
+
+                    return $number;
+                });
+            ',
+            strtr('Either<"not_number", int>', [
+                'Either' => Either::class,
+            ])
+        );
+
+        $this->assertBlockType(
+        /** @lang InjectablePHP */ '
+                /** @var array{name?: string} $hasName */
+                $hasName = [];
+
+                $result = Fp\Functional\Either\Either::do(function() use ($hasName) {
+                    yield Fp\Evidence\proveTrue(array_key_exists("name", $hasName))->toRight(fn() => "no_prop");
+
+                    return $hasName["name"];
+                });
+            ',
+            strtr('Either<"no_prop", string>', [
+                'Either' => Either::class,
             ])
         );
     }


### PR DESCRIPTION
solves #12 
Now assertions preserves not only for `Option::do`  but and for `Either::do`