### PR TITLE
Type refinements for Fp\Collection\filter

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,7 @@
     <plugins>
         <pluginClass class="Klimick\PsalmShowType\ShowTypePlugin"/>
 
+        <pluginClass class="Fp\Psalm\FilterFunctionReturnTypeProvider"/>
         <pluginClass class="Fp\Psalm\PartialFunctionReturnTypeProvider"/>
         <pluginClass class="Fp\Psalm\PartitionFunctionReturnTypeProvider"/>
         <pluginClass class="Fp\Psalm\PluckFunctionReturnTypeProvider"/>

--- a/src/Fp/Psalm/FilterFunctionReturnTypeProvider.php
+++ b/src/Fp/Psalm/FilterFunctionReturnTypeProvider.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm;
+
+use Psalm\Type;
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\RegistrationInterface;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Fp\Psalm\TypeRefinement\RefineByPredicate;
+use Fp\Psalm\TypeRefinement\RefinementContext;
+use Fp\Psalm\TypeRefinement\RefinementResult;
+use Fp\Functional\Option\Option;
+use SimpleXMLElement;
+use function Fp\Cast\asList;
+use function Fp\Collection\firstOf;
+use function Fp\Evidence\proveOf;
+use function Fp\Evidence\proveTrue;
+
+final class FilterFunctionReturnTypeProvider implements PluginEntryPointInterface, FunctionReturnTypeProviderInterface
+{
+    public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
+    {
+        $registration->registerHooksFromClass(self::class);
+    }
+
+    public static function getFunctionIds(): array
+    {
+        return ['fp\collection\filter'];
+    }
+
+    /**
+     * @psalm-suppress InternalMethod
+     */
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $reconciled = Option::do(function() use ($event) {
+            $source = yield proveOf($event->getStatementsSource(), StatementsAnalyzer::class);
+
+            $call_args = $event->getCallArgs();
+            yield proveTrue(count($call_args) >= 2);
+
+            $result = yield RefineByPredicate::for(
+                new RefinementContext(
+                    collection_arg: $call_args[0],
+                    predicate_arg: $call_args[1],
+                    execution_context: $event->getContext(),
+                    codebase: $source->getCodebase(),
+                    provider: $source->getNodeTypeProvider(),
+                    source: $source,
+                )
+            );
+
+            return yield self::preserveKeys($event)
+                ->map(fn($preserve_keys) => match ($preserve_keys) {
+                    true => self::arrayType($result),
+                    false => self::listType($result),
+                });
+        });
+
+        return $reconciled->get();
+    }
+
+    private static function arrayType(RefinementResult $result): Type\Union
+    {
+        return new Type\Union([
+            new Type\Atomic\TArray([
+                $result->collection_key_type,
+                $result->collection_value_type,
+            ]),
+        ]);
+    }
+
+    private static function listType(RefinementResult $result): Type\Union
+    {
+        return new Type\Union([
+            new Type\Atomic\TList($result->collection_value_type),
+        ]);
+    }
+
+    /**
+     * @return Option<bool>
+     */
+    private static function preserveKeys(FunctionReturnTypeProviderEvent $event): Option
+    {
+        return Option::do(function() use ($event) {
+            $call_args = $event->getCallArgs();
+
+            // $preserveKeys true by default
+            if (3 !== count($call_args)) {
+                return true;
+            }
+
+            $preserve_keys_type = yield Option::of(
+                $event
+                    ->getStatementsSource()
+                    ->getNodeTypeProvider()
+                    ->getType($call_args[2]->value)
+            );
+
+            $atomics = asList($preserve_keys_type->getAtomicTypes());
+            yield proveTrue(1 === count($atomics));
+
+            return yield firstOf($atomics, Type\Atomic\TBool::class)
+                ->flatMap(fn($bool) => match ($bool::class) {
+                    Type\Atomic\TTrue::class => Option::some(true),
+                    Type\Atomic\TFalse::class => Option::some(false),
+                    default => Option::none(), // non literal bool
+                });
+        });
+    }
+}

--- a/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
+++ b/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
@@ -33,7 +33,7 @@ final class RefineByPredicate
     public static function for(RefinementContext $context): Option
     {
         return Option::do(function() use ($context) {
-            [$collection_key_type, $collection_val_type] = yield self::getCollectionTypeParameter(
+            [$collection_key_type, $collection_val_type] = yield self::getCollectionTypeParameters(
                 collection_arg: $context->collection_arg,
                 provider: $context->provider
             );
@@ -64,7 +64,7 @@ final class RefineByPredicate
      *
      * @return Option<CollectionTypeParameters>
      */
-    private static function getCollectionTypeParameter(Node\Arg $collection_arg, NodeTypeProvider $provider): Option
+    private static function getCollectionTypeParameters(Node\Arg $collection_arg, NodeTypeProvider $provider): Option
     {
         return Option::do(function() use ($collection_arg, $provider) {
             $collection_type = yield Option::of($provider->getType($collection_arg->value));

--- a/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
+++ b/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeRefinement;
+
+use PhpParser\Node;
+use Psalm\Type;
+use Fp\Functional\Option\Option;
+use Psalm\CodeLocation;
+use Psalm\Internal\Algebra;
+use Psalm\Internal\Algebra\FormulaGenerator;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\NodeTypeProvider;
+use Psalm\Type\Reconciler;
+use function Fp\Cast\asList;
+use function Fp\Collection\firstOf;
+use function Fp\Evidence\proveOf;
+use function Fp\Evidence\proveString;
+use function Fp\Evidence\proveTrue;
+
+/**
+ * @psalm-type CollectionTypeParameters = array{Type\Union, Type\Union}
+ * @psalm-type PsalmAssertions = array<string, array<array<int, string>>>
+ */
+final class RefineByPredicate
+{
+    private const COLLECTION_TYPE = '$collection_type';
+
+    /**
+     * @return Option<RefinementResult>
+     */
+    public static function for(RefinementContext $context): Option
+    {
+        return Option::do(function() use ($context) {
+            [$collection_key_type, $collection_val_type] = yield self::getCollectionTypeParameter(
+                collection_arg: $context->collection_arg,
+                provider: $context->provider
+            );
+
+            $predicate_function = yield self::getPredicateFunction($context->predicate_arg);
+            $predicate_arg_name = yield self::getPredicateArgumentName($predicate_function);
+            $predicate_return_expr = yield self::getPredicateSingleReturn($predicate_function);
+
+            $assertions = self::collectAssertions(
+                context: $context,
+                return_expr: $predicate_return_expr,
+                predicate_arg_name: $predicate_arg_name,
+            );
+
+            $refined_val_type = yield self::refine(
+                source: $context->source,
+                assertions: $assertions,
+                collection_type_param: $collection_val_type,
+                return_expr: $predicate_return_expr,
+            );
+
+            return new RefinementResult($collection_key_type, $refined_val_type);
+        });
+    }
+
+    /**
+     * Extracts collection type parameter that going to be refined.
+     *
+     * @return Option<CollectionTypeParameters>
+     */
+    private static function getCollectionTypeParameter(Node\Arg $collection_arg, NodeTypeProvider $provider): Option
+    {
+        return Option::do(function() use ($collection_arg, $provider) {
+            $collection_type = yield Option::of($provider->getType($collection_arg->value));
+
+            $atomics = asList($collection_type->getAtomicTypes());
+            yield proveTrue(1 === count($atomics));
+
+            return yield match (true) {
+                $atomics[0] instanceof Type\Atomic\TList => Option::of([Type::getInt(), $atomics[0]->type_param]),
+                $atomics[0] instanceof Type\Atomic\TArray => Option::of($atomics[0]->type_params),
+                $atomics[0] instanceof Type\Atomic\TIterable => Option::of($atomics[0]->type_params),
+                default => Option::none(),
+            };
+        });
+    }
+
+    /**
+     * Returns function if argument is Closure or ArrowFunction.
+     *
+     * @return Option<Node\Expr\Closure | Node\Expr\ArrowFunction>
+     */
+    private static function getPredicateFunction(Node\Arg $predicate_arg): Option
+    {
+        return Option::do(function() use ($predicate_arg) {
+            yield proveTrue(
+                $predicate_arg->value instanceof Node\Expr\Closure ||
+                $predicate_arg->value instanceof Node\Expr\ArrowFunction
+            );
+
+            return $predicate_arg->value;
+        });
+    }
+
+    /**
+     * Returns argument name of $predicate that going to be refined.
+     *
+     * @return Option<non-empty-string>
+     */
+    private static function getPredicateArgumentName(Node\Expr\Closure|Node\Expr\ArrowFunction $predicate): Option
+    {
+        return Option::do(function() use ($predicate) {
+            yield proveTrue(count($predicate->params) >= 1);
+            $params = $predicate->params;
+
+            return yield proveOf($params[0]->var, Node\Expr\Variable::class)
+                ->flatMap(fn($variable) => proveString($variable->name))
+                ->map(fn($name) => '$' . $name);
+        });
+    }
+
+    /**
+     * Returns single return expression of $predicate if present.
+     * Collection type parameter can be refined only for function with single return.
+     *
+     * @return Option<Node\Expr>
+     */
+    private static function getPredicateSingleReturn(Node\Expr\Closure|Node\Expr\ArrowFunction $predicate): Option
+    {
+        return Option::do(function() use ($predicate) {
+            $statements = $predicate->getStmts();
+            yield proveTrue(1 === count($statements));
+
+            return yield firstOf($statements, Node\Stmt\Return_::class)
+                ->flatMap(fn($return_statement) => Option::of($return_statement->expr));
+        });
+    }
+
+    /**
+     * Collects assertion for $predicate_arg_name from $return_expr.
+     *
+     * @return PsalmAssertions
+     */
+    private static function collectAssertions(RefinementContext $context, Node\Expr $return_expr, string $predicate_arg_name): array
+    {
+        $cond_object_id = spl_object_id($return_expr);
+
+        $filter_clauses = FormulaGenerator::getFormula(
+            $cond_object_id,
+            $cond_object_id,
+            $return_expr,
+            $context->execution_context->self,
+            $context->source,
+            $context->codebase
+        );
+
+        $assertions = [];
+
+        foreach (Algebra::getTruthsFromFormula($filter_clauses, $cond_object_id) as $key => $assertion) {
+            if (!str_starts_with($key, $predicate_arg_name)) {
+                continue;
+            }
+
+            $assertions[str_replace($predicate_arg_name, self::COLLECTION_TYPE, $key)] = $assertion;
+        }
+
+        return $assertions;
+    }
+
+    /**
+     * Reconciles $collection_type_param with $assertions using internal Psalm api.
+     *
+     * @param PsalmAssertions $assertions
+     * @return Option<Type\Union>
+     *
+     * @psalm-suppress InternalMethod
+     */
+    private static function refine(StatementsAnalyzer $source, array $assertions, Type\Union $collection_type_param, Node\Expr $return_expr): Option
+    {
+        return Option::do(function() use ($source, $assertions, $collection_type_param, $return_expr) {
+            yield proveTrue(!empty($assertions));
+
+            // reconcileKeyedTypes takes it by ref
+            $changed_var_ids = [];
+
+            $reconciled_types = Reconciler::reconcileKeyedTypes(
+                new_types: $assertions,
+                active_new_types: $assertions,
+                existing_types: [self::COLLECTION_TYPE => $collection_type_param],
+                changed_var_ids: $changed_var_ids,
+                referenced_var_ids: [self::COLLECTION_TYPE => true],
+                statements_analyzer: $source,
+                template_type_map: $source->getTemplateTypeMap() ?: [],
+                inside_loop: false,
+                code_location: new CodeLocation($source, $return_expr)
+            );
+
+            return yield Option::of($reconciled_types[self::COLLECTION_TYPE] ?? null);
+        });
+    }
+}

--- a/src/Fp/Psalm/TypeRefinement/RefinementContext.php
+++ b/src/Fp/Psalm/TypeRefinement/RefinementContext.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeRefinement;
+
+use PhpParser\Node\Arg;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\NodeTypeProvider;
+
+/**
+ * @psalm-immutable
+ */
+final class RefinementContext
+{
+    public function __construct(
+        public Arg $collection_arg,
+        public Arg $predicate_arg,
+        public Context $execution_context,
+        public Codebase $codebase,
+        public NodeTypeProvider $provider,
+        public StatementsAnalyzer $source,
+    ) { }
+}

--- a/src/Fp/Psalm/TypeRefinement/RefinementResult.php
+++ b/src/Fp/Psalm/TypeRefinement/RefinementResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeRefinement;
+
+use Psalm\Type;
+
+/**
+ * @psalm-immutable
+ */
+final class RefinementResult
+{
+    public function __construct(
+        public Type\Union $collection_key_type,
+        public Type\Union $collection_value_type,
+    ) { }
+}

--- a/tests/Static/Functions/Collection/FilterTest.php
+++ b/tests/Static/Functions/Collection/FilterTest.php
@@ -10,18 +10,117 @@ final class FilterTest extends PhpBlockTestCase
 {
     public function testWithArray(): void
     {
-        $phpBlock = /** @lang InjectablePHP */ '
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
             /** 
              * @psalm-return array<string, int> 
              */
             function getCollection(): array { return []; }
-            
-            $result = \Fp\Collection\filter(
+
+            $result = filter(
                 getCollection(),
                 fn(int $v, string $k) => true
             );
         ';
 
         $this->assertBlockType($phpBlock, 'array<string, int>');
+    }
+
+    public function testReconciliationWithArray(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, null|int> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(null|int $v) => null !== $v
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<string, int>');
+    }
+
+    public function testReconciliationWithoutPreservingKeys(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, null|int> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(null|int $v) => null !== $v,
+                preserveKeys: false,
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'list<int>');
+    }
+
+    public function testReconciliationWithShapes(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-type Shape = array{name?: string, postcode?: int|string} 
+             * @psalm-return array<string, Shape> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(array $v) => 
+                    array_key_exists("name", $v) &&
+                    array_key_exists("postcode", $v) &&
+                    is_int($v["postcode"])
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<string, array{name: string, postcode: int}>');
+    }
+
+    public function testReconciliationWithPsalmAssert(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, array> 
+             */
+            function getCollection(): array { return []; }
+
+            /**
+             * @psalm-type Shape = array{name: string, postcode: int}
+             * @psalm-assert-if-true Shape $shape
+             */
+            function isValidShape(array $shape): bool
+            {
+                return array_key_exists("name", $shape) && 
+                    array_key_exists("postcode", $shape) &&
+                    is_int($shape["postcode"]);
+            }
+
+            $result = filter(
+                getCollection(),
+                fn(array $v) => isValidShape($v)
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<string, array{name: string, postcode: int}>');
     }
 }


### PR DESCRIPTION
resolves #19

It covers support for `list`, `array` and `iterable` types.
If need more, other types can be added here: `RefineByPredicate::getCollectionTypeParameters`