### PR TITLE
Feature/group type inference improvement

### DIFF
--- a/src/Fp/Functions/Collection/Group.php
+++ b/src/Fp/Functions/Collection/Group.php
@@ -22,7 +22,11 @@ namespace Fp\Collection;
  * @psalm-param iterable<TK, TV> $collection
  * @psalm-param callable(TV, TK): TGroupKey $callback
  *
- * @psalm-return array<TGroupKey, array<TK, TV>>
+ * @psalm-return (
+ *		$collection is non-empty-array ? non-empty-array<TGroupKey, array<TK, TV>> : (
+ *	  	$collection is non-empty-list ? non-empty-array<TGroupKey, array<TK, TV>> : (
+ *		array<TGroupKey, array<TK, TV>>
+ * )))
  */
 function group(iterable $collection, callable $callback): array
 {

--- a/src/Fp/Functions/Collection/Group.php
+++ b/src/Fp/Functions/Collection/Group.php
@@ -15,13 +15,14 @@ namespace Fp\Collection;
  * => [1 => [1], 2 => [2], 3 => [3]]
  *
  *
+ * @psalm-template TGroupKey of array-key
  * @psalm-template TK of array-key
  * @psalm-template TV
  *
  * @psalm-param iterable<TK, TV> $collection
- * @psalm-param callable(TV, TK): array-key $callback
+ * @psalm-param callable(TV, TK): TGroupKey $callback
  *
- * @psalm-return array<array-key, array<TK, TV>>
+ * @psalm-return array<TGroupKey, array<TK, TV>>
  */
 function group(iterable $collection, callable $callback): array
 {

--- a/tests/Static/Functions/Collection/GroupTest.php
+++ b/tests/Static/Functions/Collection/GroupTest.php
@@ -15,13 +15,65 @@ final class GroupTest extends PhpBlockTestCase
              * @psalm-return array<string, int> 
              */
             function getCollection(): array { return []; }
-            
+
             $result = \Fp\Collection\group(
                 getCollection(),
-                fn(int $v, string $k) => $k . "10"
+                fn(int $v, string $k) => /** @var array-key */ $k . "10"
             );
         ';
 
-        $this->assertBlockType($phpBlock, 'array<array-key, array<string, int>>');
+        $this->assertBlockType($phpBlock, 'array<non-empty-string, array<string, int>>');
+    }
+
+    public function testWithListInferGroupKey(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return list<string> 
+             */
+            function getCollection(): array { return []; }
+            
+            $result = \Fp\Collection\group(
+                getCollection(),
+                fn(string $value) => $value . "10"
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<non-empty-string, array<int, string>>');
+    }
+
+    public function testWithArrayInferGroupKey(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return array<non-empty-string, string>
+             */
+            function getCollection(): array { return []; }
+            
+            $result = \Fp\Collection\group(
+                getCollection(),
+                fn(string $value) => $value . "10"
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<non-empty-string, array<non-empty-string, string>>');
+    }
+
+    public function testWithArrayAndGroupKeyAsTypeAlias()
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-type Alias = string
+             * @psalm-return array<Alias, int>
+             */
+            function getCollection(): array { return []; }
+            
+            $result = \Fp\Collection\group(
+                getCollection(),
+                fn(string $value) => $value
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'array<string, array<string, int>>');
     }
 }

--- a/tests/Static/Functions/Collection/GroupTest.php
+++ b/tests/Static/Functions/Collection/GroupTest.php
@@ -25,6 +25,40 @@ final class GroupTest extends PhpBlockTestCase
         $this->assertBlockType($phpBlock, 'array<non-empty-string, array<string, int>>');
     }
 
+    public function testWithNonEmptyArray(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return non-empty-array<string, int> 
+             */
+            function getCollection(): array { return [\'1\' => 1]; }
+
+            $result = \Fp\Collection\group(
+                getCollection(),
+                fn(int $v, string $k) => /** @var array-key */ $k . "10"
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'non-empty-array<non-empty-string, array<string, int>>');
+    }
+
+    public function testWithNonEmptyList(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return non-empty-list<int> 
+             */
+            function getCollection(): array { return [1]; }
+
+            $result = \Fp\Collection\group(
+                getCollection(),
+                fn(int $v, string $k) => /** @var array-key */ $k . "10"
+            );
+        ';
+
+        $this->assertBlockType($phpBlock, 'non-empty-array<non-empty-string, array<int, int>>');
+    }
+
     public function testWithListInferGroupKey(): void
     {
         $phpBlock = /** @lang InjectablePHP */ '


### PR DESCRIPTION
UPDATE:
- Better type inference for group key
    If we use `non-empty-string` as group key - result array would be like `array<string, array<K, V>>`
- Better type inference for return type
    If we have non empty list or array, then we always should receive at least one group as returned value