### PR TITLE
Improve asList function return type inference for non-empty-array

### DIFF
--- a/src/Fp/Functions/Cast/AsList.php
+++ b/src/Fp/Functions/Cast/AsList.php
@@ -17,7 +17,11 @@ namespace Fp\Cast;
  *
  * @psalm-param iterable<TK, TV> ...$collections
  *
- * @psalm-return list<TV>
+ * @psalm-return (
+ *     $collections is non-empty-array
+ *         ? non-empty-list<TV>
+ *         : list<TV>
+ * )
  */
 function asList(iterable ...$collections): array
 {

--- a/tests/Static/Functions/Cast/AsListTest.php
+++ b/tests/Static/Functions/Cast/AsListTest.php
@@ -16,9 +16,37 @@ final class AsListTest extends PhpBlockTestCase
              */
             function getCollection(): array { return []; }
             
-            $result = \Fp\Cast\asList(getCollection());
+            $result = Fp\Cast\asList(getCollection());
         ';
 
         $this->assertBlockType($phpBlock, 'list<int>');
+    }
+
+    public function testWithNonEmptyArray(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return non-empty-array<string, int> 
+             */
+            function getCollection(): array { return []; }
+            
+            $result = Fp\Cast\asList(getCollection());
+        ';
+
+        $this->assertBlockType($phpBlock, 'non-empty-list<int>');
+    }
+
+    public function testWithNonEmptyList(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */ '
+            /** 
+             * @psalm-return non-empty-list<int> 
+             */
+            function getCollection(): array { return []; }
+            
+            $result = Fp\Cast\asList(getCollection());
+        ';
+
+        $this->assertBlockType($phpBlock, 'non-empty-list<int>');
     }
 }


### PR DESCRIPTION
If pass to `asList` value of type `non-empty-array<K, V>` then result will be `non-empty-list<V>`:

```php
/** @var non-empty-array<string, int> $list */
$list = [
    'first' => 1,
    'second' => 2,
    'third' => 3,
];

/** @psalm-trace $_result */
$_result = asList($list); // $_result: non-empty-list<int>
```