### PR TITLE
Improve type inference for Option and Either assertion

### DIFF
--- a/src/Fp/Psalm/FunctionalPlugin.php
+++ b/src/Fp/Psalm/FunctionalPlugin.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Fp\Psalm;
 
+use Fp\Psalm\Hooks\EitherAssertionAnalysis;
 use Fp\Psalm\Hooks\EitherGetOrElseMethodReturnTypeProvider;
 use Fp\Psalm\Hooks\FilterFunctionReturnTypeProvider;
 use Fp\Psalm\Hooks\OptionGetOrElseMethodReturnTypeProvider;
+use Fp\Psalm\Hooks\OptionAssertionAnalysis;
 use Fp\Psalm\Hooks\PartialFunctionReturnTypeProvider;
 use Fp\Psalm\Hooks\PartitionFunctionReturnTypeProvider;
 use Fp\Psalm\Hooks\PluckFunctionReturnTypeProvider;
@@ -30,7 +32,9 @@ class FunctionalPlugin implements PluginEntryPointInterface
         $register(PluckFunctionReturnTypeProvider::class);
 
         $register(OptionGetOrElseMethodReturnTypeProvider::class);
+        $register(OptionAssertionAnalysis::class);
         $register(EitherGetOrElseMethodReturnTypeProvider::class);
+        $register(EitherAssertionAnalysis::class);
 
         $register(ProveTrueExpressionAnalyser::class);
     }

--- a/src/Fp/Psalm/Hooks/EitherAssertionAnalysis.php
+++ b/src/Fp/Psalm/Hooks/EitherAssertionAnalysis.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\Hooks;
+
+use Fp\Psalm\TypeAssertion\EitherToUnion;
+use Fp\Psalm\TypeAssertion\TypeAssertion;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+
+final class EitherAssertionAnalysis implements AfterMethodCallAnalysisInterface
+{
+    private const ASSERTION_METHODS = ['isLeft', 'isRight'];
+
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        TypeAssertion::changeTypeAfterAssertionCall($event, new EitherToUnion(), self::ASSERTION_METHODS);
+    }
+}

--- a/src/Fp/Psalm/Hooks/OptionAssertionAnalysis.php
+++ b/src/Fp/Psalm/Hooks/OptionAssertionAnalysis.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\Hooks;
+
+use Fp\Psalm\TypeAssertion\OptionToUnion;
+use Fp\Psalm\TypeAssertion\TypeAssertion;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+
+final class OptionAssertionAnalysis implements AfterMethodCallAnalysisInterface
+{
+    private const ASSERTION_METHODS = ['isSome', 'isNone', 'isEmpty', 'isNonEmpty'];
+
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        TypeAssertion::changeTypeAfterAssertionCall($event, new OptionToUnion(), self::ASSERTION_METHODS);
+    }
+}

--- a/src/Fp/Psalm/TypeAssertion/EitherToUnion.php
+++ b/src/Fp/Psalm/TypeAssertion/EitherToUnion.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeAssertion;
+
+use PhpParser\Node;
+use Psalm\Type;
+use Psalm\NodeTypeProvider;
+use Fp\Functional\Either\Either;
+use Fp\Functional\Either\Left;
+use Fp\Functional\Either\Right;
+use Fp\Functional\Option\Option;
+use function Fp\Collection\first;
+use function Fp\Collection\second;
+
+/**
+ * @psalm-type EitherTypeParams = array{
+ *     left: Type\Union,
+ *     right: Type\Union,
+ * }
+ */
+final class EitherToUnion implements PseudoAdtToUnion
+{
+    public function getUnion(NodeTypeProvider $type_provider, Node\Expr\MethodCall $from_assertion_method): Option
+    {
+        return PseudoAdtAtomicExtractor::extract($from_assertion_method->var, $type_provider, Either::class)
+            ->flatMap(fn($generic_object) => self::getEitherTypeParams($generic_object))
+            ->map(fn($type_params) => [
+                new Type\Atomic\TGenericObject(Right::class, [$type_params['right']]),
+                new Type\Atomic\TGenericObject(Left::class, [$type_params['left']]),
+            ])
+            ->map(fn($types) => new Type\Union($types));
+    }
+
+    /**
+     * @return Option<EitherTypeParams>
+     */
+    private static function getEitherTypeParams(Type\Atomic\TGenericObject $generic_object): Option
+    {
+        return Option::do(function() use ($generic_object) {
+            $left = yield first($generic_object->type_params);
+            $right = yield second($generic_object->type_params);
+
+            return [
+                'left' => $left,
+                'right' => $right,
+            ];
+        });
+    }
+}

--- a/src/Fp/Psalm/TypeAssertion/OptionToUnion.php
+++ b/src/Fp/Psalm/TypeAssertion/OptionToUnion.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeAssertion;
+
+use PhpParser\Node;
+use Psalm\Type;
+use Psalm\NodeTypeProvider;
+use Fp\Functional\Option\None;
+use Fp\Functional\Option\Some;
+use Fp\Functional\Option\Option;
+use function Fp\Collection\first;
+
+final class OptionToUnion implements PseudoAdtToUnion
+{
+    public function getUnion(NodeTypeProvider $type_provider, Node\Expr\MethodCall $from_assertion_method): Option
+    {
+        return PseudoAdtAtomicExtractor::extract($from_assertion_method->var, $type_provider, Option::class)
+            ->flatMap(fn($generic_object) => first($generic_object->type_params))
+            ->map(fn($type_param) => [
+                new Type\Atomic\TGenericObject(Some::class, [$type_param]),
+                new Type\Atomic\TNamedObject(None::class),
+            ])
+            ->map(fn($types) => new Type\Union($types));
+    }
+}

--- a/src/Fp/Psalm/TypeAssertion/PseudoAdtAtomicExtractor.php
+++ b/src/Fp/Psalm/TypeAssertion/PseudoAdtAtomicExtractor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeAssertion;
+
+use PhpParser\Node;
+use Fp\Functional\Option\Option;
+use Psalm\NodeTypeProvider;
+use Psalm\Type;
+use function Fp\Cast\asList;
+use function Fp\Evidence\proveOf;
+use function Fp\Evidence\proveTrue;
+
+/**
+ * @psalm-type NodeWithType
+ *     = Node\Expr
+ *     | Node\Name
+ *     | Node\Stmt\Return_
+ */
+final class PseudoAdtAtomicExtractor
+{
+    /**
+     * @param NodeWithType $node
+     * @return Option<Type\Atomic\TGenericObject>
+     */
+    public static function extract(Node $node, NodeTypeProvider $provider, string $adtClass): Option
+    {
+        return Option::do(function() use ($node, $provider, $adtClass) {
+            $type = yield Option::fromNullable($provider->getType($node));
+
+            $atomics = asList($type->getAtomicTypes());
+            yield proveTrue(1 === count($atomics));
+
+            $generic_object = yield proveOf($atomics[0], Type\Atomic\TGenericObject::class);
+            yield proveTrue($adtClass === $generic_object->value);
+
+            return $generic_object;
+        });
+    }
+}

--- a/src/Fp/Psalm/TypeAssertion/PseudoAdtToUnion.php
+++ b/src/Fp/Psalm/TypeAssertion/PseudoAdtToUnion.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeAssertion;
+
+use Psalm\Type;
+use Psalm\NodeTypeProvider;
+use PhpParser\Node;
+use Fp\Functional\Option\Option;
+
+interface PseudoAdtToUnion
+{
+    /**
+     * @return Option<Type\Union>
+     */
+    public function getUnion(NodeTypeProvider $type_provider, Node\Expr\MethodCall $from_assertion_method): Option;
+}

--- a/src/Fp/Psalm/TypeAssertion/TypeAssertion.php
+++ b/src/Fp/Psalm/TypeAssertion/TypeAssertion.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Psalm\TypeAssertion;
+
+use PhpParser\Node;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+use Fp\Functional\Option\Option;
+use function Fp\Evidence\proveOf;
+use function Fp\Evidence\proveString;
+use function Fp\Evidence\proveTrue;
+
+final class TypeAssertion
+{
+    /**
+     * Turns known pseudo ADT to union.
+     * For example Either<L, R> to Left<L> | Right<R>
+     * or Option<T> to None | Some<T>.
+     *
+     * @param non-empty-array<string> $assertion_methods
+     */
+    public static function changeTypeAfterAssertionCall(
+        AfterMethodCallAnalysisEvent $event,
+        PseudoAdtToUnion $pseudo_adt_to_union,
+        array $assertion_methods,
+    ): void
+    {
+        Option::do(function() use ($event, $pseudo_adt_to_union, $assertion_methods) {
+            $context = $event->getContext();
+            $source = $event->getStatementsSource();
+            $type_provider = $source->getNodeTypeProvider();
+
+            $assertion_method = yield self::getAssertionMethodCall($event->getExpr(), $assertion_methods);
+            $variable_name = yield self::getVariableName($assertion_method);
+
+            $adt_union = yield $pseudo_adt_to_union->getUnion($type_provider, $assertion_method);
+
+            $type_provider->setType($assertion_method->var, $adt_union);
+            $context->vars_in_scope[$variable_name] = $adt_union;
+        });
+    }
+
+    /**
+     * @param non-empty-array<string> $assertion_methods
+     * @return Option<Node\Expr\MethodCall>
+     */
+    private static function getAssertionMethodCall(Node\Expr $expr, array $assertion_methods): Option
+    {
+        return Option::do(function() use ($expr, $assertion_methods) {
+            $method_call = yield proveOf($expr, Node\Expr\MethodCall::class);
+            $method_identifier = yield proveOf($method_call->name, Node\Identifier::class);
+
+            yield proveTrue(
+                in_array($method_identifier->name, $assertion_methods, true)
+            );
+
+            return $method_call;
+        });
+    }
+
+    /**
+     * @return Option<string>
+     */
+    private static function getVariableName(Node\Expr\MethodCall $method_call): Option
+    {
+        return Option::do(function() use ($method_call) {
+            $variable = yield proveOf($method_call->var, Node\Expr\Variable::class);
+            $name = yield proveString($variable->name);
+
+            return '$' . $name;
+        });
+    }
+}

--- a/tests/Static/Classes/Either/EitherAssertionTest.php
+++ b/tests/Static/Classes/Either/EitherAssertionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Static\Classes\Either;
+
+use Fp\Functional\Either\Either;
+use Fp\Functional\Either\Left;
+use Fp\Functional\Either\Right;
+use Tests\PhpBlockTestCase;
+
+final class EitherAssertionTest extends PhpBlockTestCase
+{
+    public function testIsRightWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Either\Either;
+
+                /** @var Either<string, int> */
+                $either = Either::left("err");
+
+                if ($either->isRight()) {
+                    /** @psalm-trace $right */
+                    $right = $either;
+                } else {
+                    /** @psalm-trace $left */
+                    $left = $either;
+                }
+            ',
+            Right::class . '<int>',
+            Left::class . '<string>',
+        );
+    }
+
+    public function testIsLeftWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Either\Either;
+
+                /** @var Either<string, int> */
+                $either = Either::left("err");
+
+                if ($either->isLeft()) {
+                    /** @psalm-trace $left */
+                    $left = $either;
+                } else {
+                    /** @psalm-trace $right */
+                    $right = $either;
+                }
+            ',
+            Left::class . '<string>',
+            Right::class . '<int>',
+        );
+    }
+
+    public function testIsRightWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Either\Either;
+
+                /** @var Either<string, int> */
+                $either = Either::left("err");
+
+                $either->isRight()
+                    ? call_user_func(function() use ($either) {
+                        /** @psalm-trace $right */
+                        $right = $either;
+                    })
+                    : call_user_func(function() use ($either) {
+                        /** @psalm-trace $left */
+                        $left = $either;
+                    });
+            ',
+            Right::class . '<int>',
+            Left::class . '<string>',
+        );
+    }
+
+    public function testIsLeftWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Either\Either;
+
+                /** @var Either<string, int> */
+                $either = Either::left("err");
+
+                $either->isLeft()
+                    ? call_user_func(function() use ($either) {
+                        /** @psalm-trace $left */
+                        $left = $either;
+                    })
+                    : call_user_func(function() use ($either) {
+                        /** @psalm-trace $right */
+                        $right = $either;
+                    });
+            ',
+            Left::class . '<string>',
+            Right::class . '<int>',
+        );
+    }
+}

--- a/tests/Static/Classes/Option/OptionAssertionTest.php
+++ b/tests/Static/Classes/Option/OptionAssertionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Static\Classes\Option;
+
+use Fp\Functional\Option\None;
+use Fp\Functional\Option\Option;
+use Fp\Functional\Option\Some;
+use Tests\PhpBlockTestCase;
+
+final class OptionAssertionTest extends PhpBlockTestCase
+{
+    public function testIsSomeWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                if ($option->isSome()) {
+                    /** @psalm-trace $some */
+                    $some = $option;
+                } else {
+                    /** @psalm-trace $none */
+                    $none = $option;
+                }
+            ',
+            Some::class . '<int>',
+            None::class,
+        );
+    }
+
+    public function testIsNonEmptyWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                if ($option->isNonEmpty()) {
+                    /** @psalm-trace $some */
+                    $some = $option;
+                } else {
+                    /** @psalm-trace $none */
+                    $none = $option;
+                }
+            ',
+            Some::class . '<int>',
+            None::class,
+        );
+    }
+
+    public function testIsNoneWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                if ($option->isNone()) {
+                    /** @psalm-trace $none */
+                    $none = $option;
+                } else {
+                    /** @psalm-trace $some */
+                    $some = $option;
+                }
+            ',
+            None::class,
+            Some::class . '<int>',
+        );
+    }
+
+    public function testIsEmptyWithIfStatement(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                if ($option->isEmpty()) {
+                    /** @psalm-trace $none */
+                    $none = $option;
+                } else {
+                    /** @psalm-trace $some */
+                    $some = $option;
+                }
+            ',
+            None::class,
+            Some::class . '<int>',
+        );
+    }
+
+    public function testIsSomeWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                $option->isSome()
+                    ? call_user_func(function() use ($option) {
+                        /** @psalm-trace $option */
+                        $some = $option;
+                    })
+                    : call_user_func(function() use ($option) {
+                        /** @psalm-trace $none */
+                        $none = $option;
+                    });
+            ',
+            Some::class . '<int>',
+            None::class,
+        );
+    }
+
+    public function testIsNonEmptyWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                $option->isNonEmpty()
+                    ? call_user_func(function() use ($option) {
+                        /** @psalm-trace $some */
+                        $some = $option;
+                    })
+                    : call_user_func(function() use ($option) {
+                        /** @psalm-trace $none */
+                        $none = $option;
+                    });
+            ',
+            Some::class . '<int>',
+            None::class,
+        );
+    }
+
+    public function testIsNoneWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                $option->isNone()
+                    ? call_user_func(function() use ($option) {
+                        /** @psalm-trace $none */
+                        $none = $option;
+                    })
+                    : call_user_func(function() use ($option) {
+                        /** @psalm-trace $some */
+                        $some = $option;    
+                    });
+            ',
+            None::class,
+            Some::class . '<int>',
+        );
+    }
+
+    public function testIsEmptyWithTernaryOperator(): void
+    {
+        $this->assertBlockTypes(
+        /** @lang InjectablePHP */ '
+                use Fp\Functional\Option\Option;
+
+                /** @var Option<int> */
+                $option = Option::none();
+
+                $option->isEmpty()
+                    ? call_user_func(function() use ($option) {
+                        /** @psalm-trace $none */
+                        $none = $option;
+                    })
+                    : call_user_func(function() use ($option) {
+                        /** @psalm-trace $some */
+                        $some = $option;    
+                    });
+            ',
+            None::class,
+            Some::class . '<int>',
+        );
+    }
+}


### PR DESCRIPTION
This PR aim to fix wrong type inference for `Option` and `Either` assertion methods.
Example of correct inference:
```php
/**
 * @return Option<int>
 */
function getOption(): Option
{
    return Option::none();
}

/** @psalm-param (Some<int>) $_some */
function assertIsSome($_some): void {}

/** @psalm-param (None) $_none */
function assertIsNone($_none): void {}

function test(): void
{
    $opt = getOption();

    if ($opt->isSome()) {
        assertIsSome($opt); // $opt is Some<int> at this point
    } else {
        assertIsNone($opt); // $opt is None, before it was Option<int>
    }
}
```