### PR TITLE
Fix filter return provider

### DIFF
--- a/src/Fp/Psalm/Hooks/FilterFunctionReturnTypeProvider.php
+++ b/src/Fp/Psalm/Hooks/FilterFunctionReturnTypeProvider.php
@@ -69,6 +69,9 @@ final class FilterFunctionReturnTypeProvider implements FunctionReturnTypeProvid
         ]);
     }
 
+    /**
+     * @psalm-return Option<Type\Union>
+     */
     private static function getReturnType(FunctionReturnTypeProviderEvent $event, RefinementResult $result): Option
     {
         $call_args = $event->getCallArgs();

--- a/src/Fp/Psalm/Hooks/FilterFunctionReturnTypeProvider.php
+++ b/src/Fp/Psalm/Hooks/FilterFunctionReturnTypeProvider.php
@@ -82,9 +82,9 @@ final class FilterFunctionReturnTypeProvider implements FunctionReturnTypeProvid
         return Option::do(function() use ($event) {
             $call_args = $event->getCallArgs();
 
-            // $preserveKeys true by default
+            // $preserveKeys false by default
             if (3 !== count($call_args)) {
-                return true;
+                return false;
             }
 
             $preserve_keys_type = yield Option::fromNullable(

--- a/src/Fp/Psalm/Psalm.php
+++ b/src/Fp/Psalm/Psalm.php
@@ -9,12 +9,14 @@ use PhpParser\Node\Arg;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\StatementsSource;
+use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TCallable;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
 
 use function Fp\Cast\asList;
 use function Fp\Collection\head;
+use function Fp\Evidence\proveTrue;
 
 /**
  * @internal
@@ -27,6 +29,19 @@ class Psalm
     public static function getArgType(Arg $arg, StatementsSource $source): Option
     {
         return Option::fromNullable($source->getNodeTypeProvider()->getType($arg->value));
+    }
+
+    /**
+     * @psalm-return Option<Atomic>
+     */
+    public static function getSingeAtomic(Union $union): Option
+    {
+        return Option::do(function() use ($union) {
+            $atomics = asList($union->getAtomicTypes());
+            yield proveTrue(1 === count($atomics));
+
+            return $atomics[0];
+        });
     }
 
     /**

--- a/src/Fp/Psalm/TypeAssertion/PseudoAdtAtomicExtractor.php
+++ b/src/Fp/Psalm/TypeAssertion/PseudoAdtAtomicExtractor.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Fp\Psalm\TypeAssertion;
 
+use Fp\Psalm\Psalm;
 use PhpParser\Node;
 use Fp\Functional\Option\Option;
 use Psalm\NodeTypeProvider;
 use Psalm\Type;
-use function Fp\Cast\asList;
+
 use function Fp\Evidence\proveOf;
 use function Fp\Evidence\proveTrue;
 
@@ -27,12 +28,10 @@ final class PseudoAdtAtomicExtractor
     public static function extract(Node $node, NodeTypeProvider $provider, string $adtClass): Option
     {
         return Option::do(function() use ($node, $provider, $adtClass) {
-            $type = yield Option::fromNullable($provider->getType($node));
+            $generic_object = yield Option::fromNullable($provider->getType($node))
+                ->flatMap(fn($type) => Psalm::getSingeAtomic($type))
+                ->flatMap(fn($atomic) => proveOf($atomic, Type\Atomic\TGenericObject::class));
 
-            $atomics = asList($type->getAtomicTypes());
-            yield proveTrue(1 === count($atomics));
-
-            $generic_object = yield proveOf($atomics[0], Type\Atomic\TGenericObject::class);
             yield proveTrue($adtClass === $generic_object->value);
 
             return $generic_object;

--- a/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
+++ b/src/Fp/Psalm/TypeRefinement/RefineByPredicate.php
@@ -48,14 +48,14 @@ final class RefineByPredicate
                 predicate_arg_name: $predicate_arg_name,
             );
 
-            $refined_val_type = yield self::refine(
+            $refined_val_type = self::refine(
                 source: $context->source,
                 assertions: $assertions,
                 collection_type_param: $collection_val_type,
                 return_expr: $predicate_return_expr,
             );
 
-            return new RefinementResult($collection_key_type, $refined_val_type);
+            return new RefinementResult($collection_key_type, $refined_val_type->getOrElse($collection_val_type));
         });
     }
 

--- a/tests/Static/Functions/Collection/FilterTest.php
+++ b/tests/Static/Functions/Collection/FilterTest.php
@@ -22,7 +22,7 @@ final class FilterTest extends PhpBlockTestCase
             $result = filter(
                 getCollection(),
                 fn(int $v, string $k) => true,
-                true
+                preserveKeys: true
             );
         ';
 
@@ -46,7 +46,7 @@ final class FilterTest extends PhpBlockTestCase
             );
         ';
 
-        $this->assertBlockTypes($phpBlock, 'array<string, int>');
+        $this->assertBlockTypes($phpBlock, 'list<int>');
     }
 
     public function testReconciliationWithoutPreservingKeys(): void
@@ -91,7 +91,7 @@ final class FilterTest extends PhpBlockTestCase
             );
         ';
 
-        $this->assertBlockTypes($phpBlock, 'array<string, array{name: string, postcode: int}>');
+        $this->assertBlockTypes($phpBlock, 'list<array{name: string, postcode: int}>');
     }
 
     public function testReconciliationWithPsalmAssert(): void
@@ -122,6 +122,6 @@ final class FilterTest extends PhpBlockTestCase
             );
         ';
 
-        $this->assertBlockTypes($phpBlock, 'array<string, array{name: string, postcode: int}>');
+        $this->assertBlockTypes($phpBlock, 'list<array{name: string, postcode: int}>');
     }
 }

--- a/tests/Static/Functions/Collection/FilterTest.php
+++ b/tests/Static/Functions/Collection/FilterTest.php
@@ -8,7 +8,7 @@ use Tests\PhpBlockTestCase;
 
 final class FilterTest extends PhpBlockTestCase
 {
-    public function testWithArray(): void
+    public function testPreserveKeysTrue(): void
     {
         $phpBlock = /** @lang InjectablePHP */
             '
@@ -29,7 +29,69 @@ final class FilterTest extends PhpBlockTestCase
         $this->assertBlockTypes($phpBlock, 'array<string, int>');
     }
 
-    public function testReconciliationWithArray(): void
+    public function testPreserveKeysExplicitFalse(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, int> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(int $v, string $k) => true,
+                preserveKeys: false
+            );
+        ';
+
+        $this->assertBlockTypes($phpBlock, 'list<int>');
+    }
+
+    public function testPreserveKeysImplicitFalse(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, int> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(int $v, string $k) => true,
+            );
+        ';
+
+        $this->assertBlockTypes($phpBlock, 'list<int>');
+    }
+
+    public function testPreserveKeysIsNonLiteralBool(): void
+    {
+        $phpBlock = /** @lang InjectablePHP */
+            '
+            use function Fp\Collection\filter;
+
+            /** 
+             * @psalm-return array<string, int> 
+             */
+            function getCollection(): array { return []; }
+
+            $result = filter(
+                getCollection(),
+                fn(int $v, string $k) => true,
+                preserveKeys: (bool) rand(0, 1)
+            );
+        ';
+
+        $this->assertBlockTypes($phpBlock, 'array<string, int>');
+    }
+
+    public function testRefineNotNull(): void
     {
         $phpBlock = /** @lang InjectablePHP */
             '
@@ -49,28 +111,7 @@ final class FilterTest extends PhpBlockTestCase
         $this->assertBlockTypes($phpBlock, 'list<int>');
     }
 
-    public function testReconciliationWithoutPreservingKeys(): void
-    {
-        $phpBlock = /** @lang InjectablePHP */
-            '
-            use function Fp\Collection\filter;
-
-            /** 
-             * @psalm-return array<string, null|int> 
-             */
-            function getCollection(): array { return []; }
-
-            $result = filter(
-                getCollection(),
-                fn(null|int $v) => null !== $v,
-                preserveKeys: false,
-            );
-        ';
-
-        $this->assertBlockTypes($phpBlock, 'list<int>');
-    }
-
-    public function testReconciliationWithShapes(): void
+    public function testRefineShapeType(): void
     {
         $phpBlock = /** @lang InjectablePHP */
             '
@@ -94,7 +135,7 @@ final class FilterTest extends PhpBlockTestCase
         $this->assertBlockTypes($phpBlock, 'list<array{name: string, postcode: int}>');
     }
 
-    public function testReconciliationWithPsalmAssert(): void
+    public function testRefineShapeWithPsalmAssert(): void
     {
         $phpBlock = /** @lang InjectablePHP */
             '


### PR DESCRIPTION
Currently `$result` infers to `array<int, int>`:
```php
/** @var $numbers list<int|null> */
$numbers = [1, 2, null];
$result = filter($numbers, fn(int|null $n) => null !== $n)
```
But return type should be `list<int>` (because `preserveKeys` false by default)

Furthermore. In this case, `$result` infers to `array<string|int, int>`:

```php
/** @var $numbers list<int|null> */
$numbers = [1, 2, null];
$result = filter($numbers, fn(int|null $n) => null !== $n, preserveKeys: (bool) rand(0, 1))
```

But should be `array<int, int>` (not `list<int>` because we cannot be sure about `preserveKeys` value).

PR fixes errors from above.