### PR TITLE
`filterMap` operation

### DIFF
--- a/src/Fp/Collections/ArrayList.php
+++ b/src/Fp/Collections/ArrayList.php
@@ -176,6 +176,27 @@ final class ArrayList extends AbstractIndexedSeq
 
     /**
      * @inheritDoc
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return self<TVO>
+     */
+    public function filterMap(callable $callback): self
+    {
+        $buffer = [];
+
+        foreach ($this->elements as $element) {
+            $result = $callback($element);
+
+            if ($result->isSome()) {
+                $buffer[] = $result->get();
+            }
+        }
+
+        return new self($buffer);
+    }
+
+    /**
+     * @inheritDoc
      * @psalm-return self<TV>
      */
     public function filterNotNull(): self

--- a/src/Fp/Collections/HashMap.php
+++ b/src/Fp/Collections/HashMap.php
@@ -140,6 +140,29 @@ final class HashMap extends AbstractMap
     }
 
     /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @return self<TK, TVO>
+     */
+    public function filterMap(callable $callback): self
+    {
+        $source = function () use ($callback): Generator {
+            foreach ($this->generateEntries() as $entry) {
+                $result = $callback($entry);
+
+                if ($result->isSome()) {
+                    yield [$entry->key, $result->get()];
+                }
+
+                unset($entry);
+            }
+        };
+
+        return self::collect($source());
+    }
+
+    /**
      * @experimental
      * @psalm-template TKO
      * @psalm-template TVO

--- a/src/Fp/Collections/HashSet.php
+++ b/src/Fp/Collections/HashSet.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fp\Collections;
 
+use Fp\Functional\Option\Option;
 use Generator;
 
 /**
@@ -129,6 +130,27 @@ final class HashSet extends AbstractSet
     public function filterNotNull(): self
     {
         return $this->filter(fn($elem) => null !== $elem);
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return self<TVO>
+     */
+    public function filterMap(callable $callback): self
+    {
+        $source = function () use ($callback): Generator {
+            foreach ($this as $element) {
+                $result = $callback($element);
+
+                if ($result->isSome()) {
+                    yield $result->get();
+                }
+            }
+        };
+
+        return self::collect($source());
     }
 
     /**

--- a/src/Fp/Collections/LinkedList.php
+++ b/src/Fp/Collections/LinkedList.php
@@ -6,6 +6,7 @@ namespace Fp\Collections;
 
 use Generator;
 use Iterator;
+use Fp\Functional\Option\Option;
 
 use function Fp\of;
 
@@ -138,6 +139,27 @@ abstract class LinkedList extends AbstractLinearSeq
             foreach ($this as $element) {
                 if ($predicate($element)) {
                     yield $element;
+                }
+            }
+        };
+
+        return self::collect($source());
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return self<TVO>
+     */
+    public function filterMap(callable $callback): self
+    {
+        $source = function () use ($callback): Generator {
+            foreach ($this as $element) {
+                $result = $callback($element);
+
+                if ($result->isSome()) {
+                    yield $result->get();
                 }
             }
         };

--- a/src/Fp/Collections/MapOps.php
+++ b/src/Fp/Collections/MapOps.php
@@ -96,6 +96,24 @@ interface MapOps
     public function filter(callable $predicate): Map;
 
     /**
+     * A combined {@see MapOps::map} and {@see MapOps::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * REPL:
+     * >>> HashMap::collect([['a', 'zero'], ['b', '1'], ['c', '2']])
+     * >>>     ->filterMap(fn(Entry $e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+     * >>>     ->toArray()
+     * => [['b', 1], ['c', 2]]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Map<TK, TVO>
+     */
+    public function filterMap(callable $callback): Map;
+
+    /**
      * Map collection and flatten the result
      *
      * REPL:

--- a/src/Fp/Collections/NonEmptyArrayList.php
+++ b/src/Fp/Collections/NonEmptyArrayList.php
@@ -218,6 +218,17 @@ final class NonEmptyArrayList extends AbstractNonEmptyIndexedSeq
 
     /**
      * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return ArrayList<TVO>
+     */
+    public function filterMap(callable $callback): ArrayList
+    {
+        return $this->arrayList->filterMap($callback);
+    }
+
+    /**
+     * @inheritDoc
      * @psalm-return ArrayList<TV>
      */
     public function filterNotNull(): ArrayList

--- a/src/Fp/Collections/NonEmptyHashMap.php
+++ b/src/Fp/Collections/NonEmptyHashMap.php
@@ -204,6 +204,17 @@ final class NonEmptyHashMap extends AbstractNonEmptyMap
     /**
      * @inheritDoc
      * @template TVO
+     * @param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @return HashMap<TK, TVO>
+     */
+    public function filterMap(callable $callback): HashMap
+    {
+        return $this->hashMap->filterMap($callback);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
      * @psalm-param callable(Entry<TK, TV>): TVO $callback
      * @psalm-return self<TK, TVO>
      */

--- a/src/Fp/Collections/NonEmptyHashSet.php
+++ b/src/Fp/Collections/NonEmptyHashSet.php
@@ -163,6 +163,17 @@ final class NonEmptyHashSet extends AbstractNonEmptySet
 
     /**
      * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Set<TVO>
+     */
+    public function filterMap(callable $callback): Set
+    {
+        return $this->set->filterMap($callback);
+    }
+
+    /**
+     * @inheritDoc
      * @psalm-return Set<TV>
      */
     public function filterNotNull(): Set

--- a/src/Fp/Collections/NonEmptyLinkedList.php
+++ b/src/Fp/Collections/NonEmptyLinkedList.php
@@ -198,6 +198,17 @@ final class NonEmptyLinkedList extends AbstractNonEmptyLinearSeq
 
     /**
      * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return LinkedList<TVO>
+     */
+    public function filterMap(callable $callback): LinkedList
+    {
+        return $this->toLinkedList()->filterMap($callback);
+    }
+
+    /**
+     * @inheritDoc
      * @psalm-return LinkedList<TV>
      */
     public function filterNotNull(): LinkedList

--- a/src/Fp/Collections/NonEmptyMapOps.php
+++ b/src/Fp/Collections/NonEmptyMapOps.php
@@ -96,6 +96,25 @@ interface NonEmptyMapOps
     public function filter(callable $predicate): Map;
 
     /**
+     * A combined {@see NonEmptyHashMap::map} and {@see NonEmptyHashMap::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     * Also, NonEmpty* prefix will be lost.
+     *
+     * REPL:
+     * >>> NonEmptyHashMap::collectNonEmpty([['a', 'zero'], ['b', '1'], ['c', '2']])
+     * >>>     ->filterMap(fn(Entry $e) => is_numeric($e->value) ? Option::some((int) $e->value) : Option::none())
+     * >>>     ->toArray()
+     * => [['b', 1], ['c', 2]]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Map<TK, TVO>
+     */
+    public function filterMap(callable $callback): Map;
+
+    /**
      * Produces a new collection of elements by mapping each element in collection
      * through a transformation function (callback)
      *

--- a/src/Fp/Collections/NonEmptySeqOps.php
+++ b/src/Fp/Collections/NonEmptySeqOps.php
@@ -150,6 +150,25 @@ interface NonEmptySeqOps
     public function filter(callable $predicate): Seq;
 
     /**
+     * A combined {@see NonEmptySeq::map} and {@see NonEmptySeq::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     * Also, NonEmpty* prefix will be lost.
+     *
+     * REPL:
+     * >>> NonEmptyLinkedList::collectNonEmpty(['zero', '1', '2'])
+     * >>>     ->filterMap(fn($elem) => is_numeric($elem) ? Option::some((int) $elem) : Option::none())
+     * >>>     ->toArray()
+     * => [1, 2]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Seq<TVO>
+     */
+    public function filterMap(callable $callback): Seq;
+
+    /**
      * Exclude null elements
      *
      * REPL:

--- a/src/Fp/Collections/NonEmptySetOps.php
+++ b/src/Fp/Collections/NonEmptySetOps.php
@@ -136,6 +136,25 @@ interface NonEmptySetOps
     public function filter(callable $predicate): Set;
 
     /**
+     * A combined {@see NonEmptySet::map} and {@see NonEmptySet::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     * Also, NonEmpty* prefix will be lost.
+     *
+     * REPL:
+     * >>> NonEmptyHashSet::collectNonEmpty(['zero', '1', '2'])
+     * >>>     ->filterMap(fn($elem) => is_numeric($elem) ? Option::some((int) $elem) : Option::none())
+     * >>>     ->toArray()
+     * => [1, 2]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Set<TVO>
+     */
+    public function filterMap(callable $callback): Set;
+
+    /**
      * Exclude null elements
      *
      * REPL:

--- a/src/Fp/Collections/SeqOps.php
+++ b/src/Fp/Collections/SeqOps.php
@@ -189,6 +189,24 @@ interface SeqOps
     public function filterOf(string $fqcn, bool $invariant = false): Seq;
 
     /**
+     * A combined {@see Seq::map} and {@see Seq::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * REPL:
+     * >>> LinkedList::collect(['zero', '1', '2'])
+     * >>>     ->filterMap(fn($elem) => is_numeric($elem) ? Option::some((int) $elem) : Option::none())
+     * >>>     ->toArray()
+     * => [1, 2]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Seq<TVO>
+     */
+    public function filterMap(callable $callback): Seq;
+
+    /**
      * Find first element which satisfies the condition
      *
      * REPL:

--- a/src/Fp/Collections/SetOps.php
+++ b/src/Fp/Collections/SetOps.php
@@ -147,6 +147,24 @@ interface SetOps
     public function filterNotNull(): Set;
 
     /**
+     * A combined {@see Set::map} and {@see Set::filter}.
+     *
+     * Filtering is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * REPL:
+     * >>> HashSet::collect(['zero', '1', '2'])
+     * >>>     ->filterMap(fn($elem) => is_numeric($elem) ? Option::some((int) $elem) : Option::none())
+     * >>>     ->toArray()
+     * => [1, 2]
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Set<TVO>
+     */
+    public function filterMap(callable $callback): Set;
+
+    /**
      * Find first element which satisfies the condition
      *
      * REPL:

--- a/tests/Runtime/Classes/ArrayList/ArrayListOpsTest.php
+++ b/tests/Runtime/Classes/ArrayList/ArrayListOpsTest.php
@@ -6,6 +6,7 @@ namespace Tests\Runtime\Classes\ArrayList;
 
 use Fp\Collections\ArrayList;
 use Fp\Collections\Seq;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Bar;
 use Tests\Mock\Foo;
@@ -83,6 +84,16 @@ final class ArrayListOpsTest extends TestCase
     {
         $linkedList = ArrayList::collect([new Foo(1), 1, new Foo(1)]);
         $this->assertEquals([1], $linkedList->filter(fn($i) => $i === 1)->toArray());
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [1, 2],
+            ArrayList::collect(['zero', '1', '2'])
+                ->filterMap(fn($e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFilterNotNull(): void

--- a/tests/Runtime/Classes/ArrayList/NonEmptyArrayListOpsTest.php
+++ b/tests/Runtime/Classes/ArrayList/NonEmptyArrayListOpsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\ArrayList;
 
 use Fp\Collections\NonEmptyArrayList;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Bar;
 use Tests\Mock\Foo;
@@ -82,6 +83,16 @@ final class NonEmptyArrayListOpsTest extends TestCase
     {
         $linkedList = NonEmptyArrayList::collectNonEmpty([new Foo(1), 1, new Foo(1)]);
         $this->assertEquals([1], $linkedList->filter(fn($i) => $i === 1)->toArray());
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [1, 2],
+            NonEmptyArrayList::collectNonEmpty(['zero', '1', '2'])
+                ->filterMap(fn($e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFilterNotNull(): void

--- a/tests/Runtime/Classes/HashMap/HashMapOpsTest.php
+++ b/tests/Runtime/Classes/HashMap/HashMapOpsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\HashMap;
 
 use Fp\Collections\HashMap;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Foo;
 
@@ -40,6 +41,16 @@ final class HashMapOpsTest extends TestCase
     {
         $hm = HashMap::collectIterable(['a' => new Foo(1), 'b' => 1, 'c' => new Foo(2)]);
         $this->assertEquals([['b', 1]], $hm->filter(fn($e) => $e->value === 1)->toArray());
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [['b', 1], ['c', 2]],
+            HashMap::collect([['a', 'zero'], ['b', '1'], ['c', '2']])
+                ->filterMap(fn($e) => is_numeric($e->value) ? Option::some((int) $e->value) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFlatMap(): void

--- a/tests/Runtime/Classes/HashMap/NonEmptyHashMapOpsTest.php
+++ b/tests/Runtime/Classes/HashMap/NonEmptyHashMapOpsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\HashMap;
 
 use Fp\Collections\NonEmptyHashMap;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Foo;
 
@@ -42,6 +43,15 @@ final class NonEmptyHashMapOpsTest extends TestCase
         $this->assertEquals([['b', 1]], $hm->filter(fn($e) => $e->value === 1)->toArray());
     }
 
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [['b', 1], ['c', 2]],
+            NonEmptyHashMap::collectNonEmpty([['a', 'zero'], ['b', '1'], ['c', '2']])
+                ->filterMap(fn($e) => is_numeric($e->value) ? Option::some((int) $e->value) : Option::none())
+                ->toArray()
+        );
+    }
 
     public function testMap(): void
     {

--- a/tests/Runtime/Classes/HashSet/HashSetOpsTest.php
+++ b/tests/Runtime/Classes/HashSet/HashSetOpsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\HashSet;
 
 use Fp\Collections\HashSet;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Bar;
 use Tests\Mock\Foo;
@@ -69,6 +70,16 @@ final class HashSetOpsTest extends TestCase
         $hs = HashSet::collect([new Foo(1), 1, 1, new Foo(1)]);
         $this->assertEquals([1], $hs->filter(fn($i) => $i === 1)->toArray());
         $this->assertEquals([1], HashSet::collect([1, null])->filterNotNull()->toArray());
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [1, 2],
+            HashSet::collect(['zero', '1', '2'])
+                ->filterMap(fn($e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFirstsAndLasts(): void

--- a/tests/Runtime/Classes/HashSet/NonEmptyHashSetOpsTest.php
+++ b/tests/Runtime/Classes/HashSet/NonEmptyHashSetOpsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\HashSet;
 
 use Fp\Collections\NonEmptyHashSet;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Bar;
 use Tests\Mock\Foo;
@@ -70,6 +71,16 @@ final class NonEmptyHashSetOpsTest extends TestCase
         $this->assertEquals([1], $hs->filter(fn($i) => $i === 1)->toArray());
         $this->assertEquals([1], NonEmptyHashSet::collectNonEmpty([1, null])->filterNotNull()->toArray());
 
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [1, 2],
+            NonEmptyHashSet::collectNonEmpty(['zero', '1', '2'])
+                ->filterMap(fn($e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFirstsAndLasts(): void

--- a/tests/Runtime/Classes/LinkedList/LinkedListOpsTest.php
+++ b/tests/Runtime/Classes/LinkedList/LinkedListOpsTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Runtime\Classes\LinkedList;
 
 use Fp\Collections\LinkedList;
+use Fp\Collections\NonEmptyLinkedList;
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 use Tests\Mock\Bar;
 use Tests\Mock\Foo;
@@ -78,6 +80,16 @@ final class LinkedListOpsTest extends TestCase
     {
         $linkedList = LinkedList::collect([new Foo(1), 1, new Foo(1)]);
         $this->assertEquals([1], $linkedList->filter(fn($i) => $i === 1)->toArray());
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals(
+            [1, 2],
+            NonEmptyLinkedList::collectNonEmpty(['zero', '1', '2'])
+                ->filterMap(fn($e) => is_numeric($e) ? Option::some((int) $e) : Option::none())
+                ->toArray()
+        );
     }
 
     public function testFilterNotNull(): void


### PR DESCRIPTION
This PR includes combinator for `filter` and `map` operations. 
It uses `Option` instead of `Bool` for filtering.

Use case:

```php
/**
 * @return Map<string, int>
 */
function getMap(): Map
{
    return HashMap::collect([
        ['a', 10],
        ['b', 20],
        ['c', 30],
    ]);
}

/**
 * @return Seq<string>
 */
function getKeys(): Seq
{
    return ArrayList::collect(['a', 'b']);
}

$map = getMap();

print_r(
    // ArrayList(11, 21)
    getKeys()->filterMap(fn($k) => $map($k)->map(fn($v) => $v + 1))
);

```

Because output type `TVO` can be different from input `TV` type, it also provide type assertion effect:

```php
/**
 * @return Seq<int>
 */
function getIntegers(): Seq
{
    return ArrayList::collect([1, 2, 3]);
}

// Seq<positive-int>
$onlyPositiveIntegers = getIntegers()
    ->filterMap(fn($i) => $i > 0 ? Option::some($i) : Option::none());
```