### PR TITLE
everyMap operation for collections

### DIFF
--- a/src/Fp/Collections/ArrayList.php
+++ b/src/Fp/Collections/ArrayList.php
@@ -10,6 +10,7 @@ use Fp\Operations\AppendedAllOperation;
 use Fp\Operations\AppendedOperation;
 use Fp\Operations\DropOperation;
 use Fp\Operations\DropWhileOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -204,6 +205,18 @@ final class ArrayList implements Seq
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => ArrayList::collect($gen));
     }
 
     /**

--- a/src/Fp/Collections/HashMap.php
+++ b/src/Fp/Collections/HashMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fp\Collections;
 
 use Fp\Operations\CountOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\FilterMapOperation;
 use Fp\Operations\FilterOperation;
@@ -161,6 +162,21 @@ final class HashMap implements Map, StaticStorage
         return EveryOperation::of($this->getKeyValueIterator())(
             fn($value, $key) => $predicate(new Entry($key, $value))
         );
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Option<self<TK, TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        $hs = EveryMapOperation::of($this->getKeyValueIterator())(
+            fn($value, $key) => $callback(new Entry($key, $value))
+        );
+
+        return $hs->map(fn($gen) => HashMap::collect($gen));
     }
 
     /**

--- a/src/Fp/Collections/HashSet.php
+++ b/src/Fp/Collections/HashSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fp\Collections;
 
 use Fp\Operations\CountOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -152,6 +153,18 @@ final class HashSet implements Set
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => HashSet::collect($gen));
     }
 
     /**

--- a/src/Fp/Collections/LinkedList.php
+++ b/src/Fp/Collections/LinkedList.php
@@ -11,6 +11,7 @@ use Fp\Operations\AtOperation;
 use Fp\Operations\CountOperation;
 use Fp\Operations\DropOperation;
 use Fp\Operations\DropWhileOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -184,6 +185,18 @@ abstract class LinkedList implements Seq
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => LinkedList::collect($gen));
     }
 
     /**

--- a/src/Fp/Collections/MapTerminalOps.php
+++ b/src/Fp/Collections/MapTerminalOps.php
@@ -63,6 +63,26 @@ interface MapTerminalOps
     public function every(callable $predicate): bool;
 
     /**
+     * A combined {@see Map::map} and {@see Map::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> HashMap::collectPairs(['a' => 1, 'b' => 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(HashMap('a' -> 1, 'b' -> 2))
+     *
+     * >>> HashMap::collectPairs(['a' => 0, 'b' => 1])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Option<Map<TK, TVO>>
+     */
+    public function everyMap(callable $callback): Option;
+
+    /**
      * Fold many pairs of key-value into one
      *
      * ```php

--- a/src/Fp/Collections/NonEmptyArrayList.php
+++ b/src/Fp/Collections/NonEmptyArrayList.php
@@ -7,6 +7,7 @@ namespace Fp\Collections;
 use Fp\Functional\Option\Option;
 use Fp\Operations\AppendedAllOperation;
 use Fp\Operations\AppendedOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -328,6 +329,18 @@ final class NonEmptyArrayList implements NonEmptySeq
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => NonEmptyArrayList::collectUnsafe($gen));
     }
 
     /**

--- a/src/Fp/Collections/NonEmptyHashMap.php
+++ b/src/Fp/Collections/NonEmptyHashMap.php
@@ -6,6 +6,7 @@ namespace Fp\Collections;
 
 use Fp\Functional\Option\Option;
 use Fp\Operations\CountOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\KeysOperation;
 use Fp\Operations\MapKeysOperation;
@@ -233,6 +234,21 @@ final class NonEmptyHashMap implements NonEmptyMap
         return EveryOperation::of($this->getKeyValueIterator())(
             fn($value, $key) => $predicate(new Entry($key, $value))
         );
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Option<self<TK, TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        $hs = EveryMapOperation::of($this->getKeyValueIterator())(
+            fn($value, $key) => $callback(new Entry($key, $value))
+        );
+
+        return $hs->map(fn($gen) => NonEmptyHashMap::collectUnsafe($gen));
     }
 
     /**

--- a/src/Fp/Collections/NonEmptyHashSet.php
+++ b/src/Fp/Collections/NonEmptyHashSet.php
@@ -6,6 +6,7 @@ namespace Fp\Collections;
 
 use Fp\Functional\Option\Option;
 use Fp\Operations\CountOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -210,6 +211,18 @@ final class NonEmptyHashSet implements NonEmptySet
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => NonEmptyHashSet::collectUnsafe($gen));
     }
 
     /**

--- a/src/Fp/Collections/NonEmptyLinkedList.php
+++ b/src/Fp/Collections/NonEmptyLinkedList.php
@@ -8,6 +8,7 @@ use Fp\Functional\Option\Option;
 use Fp\Operations\AppendedAllOperation;
 use Fp\Operations\AppendedOperation;
 use Fp\Operations\AtOperation;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
 use Fp\Operations\ExistsOfOperation;
@@ -325,6 +326,18 @@ final class NonEmptyLinkedList implements NonEmptySeq
     public function everyOf(string $fqcn, bool $invariant = false): bool
     {
         return EveryOfOperation::of($this->getIterator())($fqcn, $invariant);
+    }
+
+    /**
+     * @inheritDoc
+     * @template TVO
+     * @param callable(TV): Option<TVO> $callback
+     * @return Option<self<TVO>>
+     */
+    public function everyMap(callable $callback): Option
+    {
+        return EveryMapOperation::of($this->getIterator())($callback)
+            ->map(fn($gen) => NonEmptyLinkedList::collectUnsafe($gen));
     }
 
     /**

--- a/src/Fp/Collections/NonEmptyMapTerminalOps.php
+++ b/src/Fp/Collections/NonEmptyMapTerminalOps.php
@@ -61,4 +61,24 @@ interface NonEmptyMapTerminalOps
      * @psalm-param callable(Entry<TK, TV>): bool $predicate
      */
     public function every(callable $predicate): bool;
+
+    /**
+     * A combined {@see NonEmptyMap::map} and {@see NonEmptyMap::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> NonEmptyHashMap::collectPairs(['a' => 1, 'b' => 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(NonEmptyHashMap('a' -> 1, 'b' -> 2))
+     *
+     * >>> NonEmptyHashMap::collectPairs(['a' => 0, 'b' => 1])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(Entry<TK, TV>): Option<TVO> $callback
+     * @psalm-return Option<NonEmptyMap<TK, TVO>>
+     */
+    public function everyMap(callable $callback): Option;
 }

--- a/src/Fp/Collections/NonEmptySeqTerminalOps.php
+++ b/src/Fp/Collections/NonEmptySeqTerminalOps.php
@@ -75,6 +75,26 @@ interface NonEmptySeqTerminalOps
     public function everyOf(string $fqcn, bool $invariant = false): bool;
 
     /**
+     * A combined {@see NonEmptySeq::map} and {@see NonEmptySeq::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> NonEmptyArrayList::collect([1, 2, 3])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(NonEmptyArrayList(1, 2, 3))
+     *
+     * >>> NonEmptyArrayList::collect([0, 1, 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Option<NonEmptySeq<TVO>>
+     */
+    public function everyMap(callable $callback): Option;
+
+    /**
      * Find if there is element which satisfies the condition
      *
      * ```php

--- a/src/Fp/Collections/NonEmptySetTerminalOps.php
+++ b/src/Fp/Collections/NonEmptySetTerminalOps.php
@@ -78,6 +78,26 @@ interface NonEmptySetTerminalOps
     public function everyOf(string $fqcn, bool $invariant = false): bool;
 
     /**
+     * A combined {@see Set::map} and {@see Set::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> NonEmptyHashSet::collect([1, 2, 3])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(NonEmptyHashSet(1, 2, 3))
+     *
+     * >>> NonEmptyHashSet::collect([0, 1, 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Option<NonEmptySet<TVO>>
+     */
+    public function everyMap(callable $callback): Option;
+
+    /**
      * Find if there is element which satisfies the condition
      *
      * ```php

--- a/src/Fp/Collections/SeqTerminalOps.php
+++ b/src/Fp/Collections/SeqTerminalOps.php
@@ -75,6 +75,26 @@ interface SeqTerminalOps
     public function everyOf(string $fqcn, bool $invariant = false): bool;
 
     /**
+     * A combined {@see Seq::map} and {@see Seq::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> ArrayList::collect([1, 2, 3])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(ArrayList(1, 2, 3))
+     *
+     * >>> ArrayList::collect([0, 1, 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Option<Seq<TVO>>
+     */
+    public function everyMap(callable $callback): Option;
+
+    /**
      * Find if there is element which satisfies the condition
      *
      * ```php

--- a/src/Fp/Collections/SetTerminalOps.php
+++ b/src/Fp/Collections/SetTerminalOps.php
@@ -78,6 +78,26 @@ interface SetTerminalOps
     public function everyOf(string $fqcn, bool $invariant = false): bool;
 
     /**
+     * A combined {@see Set::map} and {@see Set::every}.
+     *
+     * Predicate satisfying is handled via Option instead of Boolean.
+     * So the output type TVO can be different from the input type TV.
+     *
+     * ```php
+     * >>> HashSet::collect([1, 2, 3])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => Some(HashSet(1, 2, 3))
+     *
+     * >>> HashSet::collect([0, 1, 2])->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none());
+     * => None
+     * ```
+     *
+     * @psalm-template TVO
+     * @psalm-param callable(TV): Option<TVO> $callback
+     * @psalm-return Option<Set<TVO>>
+     */
+    public function everyMap(callable $callback): Option;
+
+    /**
      * Find if there is element which satisfies the condition
      *
      * ```php

--- a/src/Fp/Functions/Collection/Every.php
+++ b/src/Fp/Functions/Collection/Every.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Fp\Collection;
 
+use Fp\Functional\Option\Option;
+use Fp\Operations\EveryMapOperation;
 use Fp\Operations\EveryOfOperation;
 use Fp\Operations\EveryOperation;
+use function Fp\Cast\asArray;
+use function Fp\Cast\asList;
 
 /**
  * Returns true if every collection element satisfies the condition
@@ -47,4 +51,22 @@ function every(iterable $collection, callable $predicate): bool
 function everyOf(iterable $collection, string $fqcn, bool $invariant = false): bool
 {
     return EveryOfOperation::of($collection)($fqcn, $invariant);
+}
+
+/**
+ * @psalm-template TK of array-key
+ * @psalm-template TVI
+ * @psalm-template TVO
+ * @psalm-param iterable<TK, TVI> $collection
+ * @psalm-param callable(TVI, TK): Option<TVO> $callback
+ * @psalm-return (
+ *    $collection is non-empty-list  ? Option<non-empty-list<TVO>>      : (
+ *    $collection is list            ? Option<list<TVO>>                : (
+ *    $collection is non-empty-array ? Option<non-empty-array<TK, TVO>> : (
+ *    Option<array<TK, TVO>>
+ * ))))
+ */
+function everyMap(iterable $collection, callable $callback): Option
+{
+    return EveryMapOperation::of($collection)($callback)->map(fn($gen) => asArray($gen));
 }

--- a/src/Fp/Functions/Collection/Filter.php
+++ b/src/Fp/Functions/Collection/Filter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fp\Collection;
 
+use Fp\Functional\Option\Option;
+use Fp\Operations\FilterMapOperation;
 use Fp\Operations\FilterNotNullOperation;
 use Fp\Operations\FilterOfOperation;
 use Fp\Operations\FilterOperation;
@@ -87,3 +89,31 @@ function filterOf(iterable $collection, string $fqcn, bool $preserveKeys = false
         : asList($gen);
 }
 
+/**
+ * A combined {@see map()} and {@see filter()}.
+ *
+ * Filtering is handled via Option instead of Boolean.
+ * So the output type TVO can be different from the input type TV.
+ * Do not preserve keys by default.
+ *
+ * ```php
+ * >>> filterMap([1, 2], fn(int $v): bool => $v === 2 ? Option::some($v) : Option::none());
+ * => [2]
+ * ```
+ *
+ * @psalm-template TK of array-key
+ * @psalm-template TV
+ * @psalm-template TVO
+ * @psalm-template TP of bool
+ * @psalm-param iterable<TK, TV> $collection
+ * @psalm-param callable(TV, TK): Option<TVO> $predicate
+ * @psalm-param TP $preserveKeys
+ * @psalm-return (TP is true ? array<TK, TVO> : list<TVO>)
+ */
+function filterMap(iterable $collection, callable $predicate, bool $preserveKeys = false): array
+{
+    $gen = FilterMapOperation::of($collection)($predicate);
+    return $preserveKeys
+        ? asArray($gen)
+        : asList($gen);
+}

--- a/src/Fp/Operations/EveryMapOperation.php
+++ b/src/Fp/Operations/EveryMapOperation.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fp\Operations;
+
+use Fp\Functional\Option\Option;
+use Generator;
+
+use function Fp\Callable\asGenerator;
+
+/**
+ * @template TK
+ * @template TV
+ * @psalm-immutable
+ * @extends AbstractOperation<TK, TV>
+ */
+class EveryMapOperation extends AbstractOperation
+{
+    /**
+     * @template TVO
+     *
+     * @param callable(TV, TK): Option<TVO> $f
+     * @return Option<Generator<TK, TVO>>
+     */
+    public function __invoke(callable $f): Option
+    {
+        $collection = [];
+
+        foreach ($this->gen as $key => $value) {
+            $mapped = $f($value, $key);
+
+            if ($mapped->isNone()) {
+                return Option::none();
+            }
+
+            $collection[] = [$key, $mapped->get()];
+        }
+
+        return Option::some(asGenerator(function() use ($collection) {
+            foreach ($collection as [$key, $value]) {
+                yield $key => $value;
+            }
+        }));
+    }
+}

--- a/src/Fp/Psalm/FunctionalPlugin.php
+++ b/src/Fp/Psalm/FunctionalPlugin.php
@@ -31,10 +31,14 @@ class FunctionalPlugin implements PluginEntryPointInterface
 {
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
     {
-        $register = function(string $hook) use ($registration): void {
-            class_exists($hook);
-            $registration->registerHooksFromClass($hook);
-        };
+        $register =
+            /**
+             * @param class-string $hook
+             */
+            function(string $hook) use ($registration): void {
+                class_exists($hook);
+                $registration->registerHooksFromClass($hook);
+            };
 
         $register(FilterFunctionReturnTypeProvider::class);
         $register(PartialFunctionReturnTypeProvider::class);

--- a/src/Fp/Psalm/Hook/AfterExpressionAnalysis/ConditionallyPureAnalyzer.php
+++ b/src/Fp/Psalm/Hook/AfterExpressionAnalysis/ConditionallyPureAnalyzer.php
@@ -56,11 +56,12 @@ final class ConditionallyPureAnalyzer implements AfterExpressionAnalysisInterfac
             $call_name = $call_info['call_name'];
             $call_node = $call_info['call_node'];
             $class_likes = $event->getCodebase()->classlikes;
+            $call_args = yield Psalm::getCallArgs($call_node);
 
             yield proveTrue($conditionally_pure($call_name) && !self::hasImpureArg(
                     $event->getCodebase(),
                     $event->getStatementsSource(),
-                    ArrayList::collect($call_node->args)
+                    $call_args,
                 ))
                 ->orElse(fn() => proveTrue($immutable_pure($call_name))
                     ->flatMap(fn() => Option::fromNullable($event->getContext()->self))

--- a/src/Fp/Psalm/Util/Extractor/ExprExtractor.php
+++ b/src/Fp/Psalm/Util/Extractor/ExprExtractor.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Fp\Psalm\Util\Extractor;
 
+use Fp\Collections\ArrayList;
 use Fp\Functional\Option\Option;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\FunctionLike;
 
 /**
@@ -22,5 +26,14 @@ trait ExprExtractor
         return Option::some($predicate_arg)
             ->map(fn(Arg $arg) => $arg->value)
             ->filter(fn(Expr $expr) => $expr instanceof FunctionLike);
+    }
+
+    /**
+     * @return Option<ArrayList<Arg>>
+     */
+    public static function getCallArgs(FuncCall|MethodCall|StaticCall $call): Option
+    {
+        return ArrayList::collect($call->args)
+            ->everyMap(fn($arg) => $arg instanceof Arg ? Option::some($arg) : Option::none());
     }
 }

--- a/src/Fp/Psalm/Util/Extractor/UnionExtractor.php
+++ b/src/Fp/Psalm/Util/Extractor/UnionExtractor.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\VariadicPlaceholder;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\StatementsSource;
@@ -24,9 +25,13 @@ trait UnionExtractor
     /**
      * @psalm-return Option<Union>
      */
-    public static function getArgUnion(Arg $arg, StatementsSource $source): Option
+    public static function getArgUnion(Arg|VariadicPlaceholder $arg, StatementsSource $source): Option
     {
-        return Option::fromNullable($source->getNodeTypeProvider()->getType($arg->value));
+        $provider = $source->getNodeTypeProvider();
+
+        return Option::some($arg)
+            ->filter(fn($arg) => $arg instanceof Arg)
+            ->flatMap(fn($arg) => Option::fromNullable($provider->getType($arg->value)));
     }
 
     /**

--- a/src/Fp/Streams/Stream.php
+++ b/src/Fp/Streams/Stream.php
@@ -152,9 +152,8 @@ final class Stream implements StreamOps, StreamEmitter, IteratorAggregate
             $prevTime = time();
 
             while (true) {
-                if ($seconds > 0) {
-                    sleep($seconds);
-                }
+                /** @psalm-suppress PossiblyInvalidArgument */
+                sleep($seconds);
 
                 $curTime = time();
                 $elapsed += $curTime - $prevTime;

--- a/src/Fp/Streams/Stream.php
+++ b/src/Fp/Streams/Stream.php
@@ -142,6 +142,7 @@ final class Stream implements StreamOps, StreamEmitter, IteratorAggregate
 
     /**
      * @inheritDoc
+     * @param 0|positive-int $seconds
      * @return self<int>
      */
     public static function awakeEvery(int $seconds): self
@@ -151,7 +152,9 @@ final class Stream implements StreamOps, StreamEmitter, IteratorAggregate
             $prevTime = time();
 
             while (true) {
-                sleep($seconds);
+                if ($seconds > 0) {
+                    sleep($seconds);
+                }
 
                 $curTime = time();
                 $elapsed += $curTime - $prevTime;

--- a/src/Fp/Streams/StreamEmitter.php
+++ b/src/Fp/Streams/StreamEmitter.php
@@ -68,6 +68,7 @@ interface StreamEmitter
      * Discrete stream that emits elapsed duration since the start time of stream consumption.
      * For example: awakeEvery(5) will return (approximately) 5s, 10s, 15s, and will lie dormant between emitted values.
      *
+     * @param 0|positive-int $seconds
      * @return Stream<int>
      */
     public static function awakeEvery(int $seconds): Stream;

--- a/tests/Runtime/Functions/Collection/EveryTest.php
+++ b/tests/Runtime/Functions/Collection/EveryTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Runtime\Functions\Collection;
 
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 
 use Tests\Mock\Foo;
 
 use function Fp\Collection\every;
+use function Fp\Collection\everyMap;
 use function Fp\Collection\everyOf;
 
 final class EveryTest extends TestCase
@@ -51,5 +53,20 @@ final class EveryTest extends TestCase
             [new Foo(1), new Foo(2), 1],
             Foo::class
         ));
+    }
+
+    public function testEveryMap(): void
+    {
+        $c = [1, 2];
+
+        $this->assertEquals(
+            Option::some($c),
+            everyMap($c, fn(int $v) => $v < 3 ? Option::some($v) : Option::none())
+        );
+
+        $this->assertEquals(
+            Option::none(),
+            everyMap($c, fn(int $v) => $v < 2 ? Option::some($v) : Option::none()),
+        );
     }
 }

--- a/tests/Runtime/Functions/Collection/FilterTest.php
+++ b/tests/Runtime/Functions/Collection/FilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Runtime\Functions\Collection;
 
+use Fp\Functional\Option\Option;
 use PHPUnit\Framework\TestCase;
 
 use Tests\Mock\Bar;
@@ -12,6 +13,7 @@ use Tests\Mock\Foo;
 use Tests\Mock\SubBar;
 
 use function Fp\Collection\filter;
+use function Fp\Collection\filterMap;
 use function Fp\Collection\filterOf;
 use function Fp\Collection\filterNotNull;
 
@@ -69,5 +71,19 @@ final class FilterTest extends TestCase
             [2 => $bar],
             filterOf([1, $subBar, $bar, 4], Bar::class, true, true)
         );
+    }
+
+    public function testFilterMap(): void
+    {
+        $this->assertEquals([1], filterMap(
+            ['a' => 1, 2],
+            fn(int $v) => $v < 2 ? Option::some($v) : Option::none(),
+        ));
+
+        $this->assertEquals(['a' => 1], filterMap(
+            ['a' =>  1, 'b' => 2],
+            fn(int $v) => $v < 2 ? Option::some($v) : Option::none(),
+            true
+        ));
     }
 }

--- a/tests/Runtime/Interfaces/Map/MapOpsTest.php
+++ b/tests/Runtime/Interfaces/Map/MapOpsTest.php
@@ -39,15 +39,18 @@ final class MapOpsTest extends TestCase
 
     public function testEveryMap(): void
     {
-        $hm = HashMap::collect(['a' => 1, 'b' => 2]);
+        $hm = HashMap::collect([
+            'a' => new Foo(1),
+            'b' => new Foo(2),
+        ]);
 
         $this->assertEquals(
             Option::some($hm),
-            $hm->everyMap(fn($x) => $x->value >= 1 ? Option::some($x->value) : Option::none())
+            $hm->everyMap(fn($x) => $x->value->a >= 1 ? Option::some($x->value) : Option::none())
         );
         $this->assertEquals(
             Option::none(),
-            $hm->everyMap(fn($x) => $x->value >= 2 ? Option::some($x->value) : Option::none())
+            $hm->everyMap(fn($x) => $x->value->a >= 2 ? Option::some($x->value) : Option::none())
         );
     }
 

--- a/tests/Runtime/Interfaces/Map/MapOpsTest.php
+++ b/tests/Runtime/Interfaces/Map/MapOpsTest.php
@@ -37,6 +37,20 @@ final class MapOpsTest extends TestCase
         $this->assertTrue($hm->every(fn($entry) => in_array($entry->key, ['a', 'b'])));
     }
 
+    public function testEveryMap(): void
+    {
+        $hm = HashMap::collect(['a' => 1, 'b' => 2]);
+
+        $this->assertEquals(
+            Option::some($hm),
+            $hm->everyMap(fn($x) => $x->value >= 1 ? Option::some($x->value) : Option::none())
+        );
+        $this->assertEquals(
+            Option::none(),
+            $hm->everyMap(fn($x) => $x->value >= 2 ? Option::some($x->value) : Option::none())
+        );
+    }
+
     public function testFilter(): void
     {
         $hm = HashMap::collect(['a' => new Foo(1), 'b' => 1, 'c' => new Foo(2)]);

--- a/tests/Runtime/Interfaces/NonEmptyMap/NonEmptyMapOpsTest.php
+++ b/tests/Runtime/Interfaces/NonEmptyMap/NonEmptyMapOpsTest.php
@@ -39,15 +39,18 @@ final class NonEmptyMapOpsTest extends TestCase
 
     public function testEveryMap(): void
     {
-        $hm = NonEmptyHashMap::collectPairsUnsafe([['a', 1], ['b', 2]]);
+        $hm = NonEmptyHashMap::collectPairsUnsafe([
+            ['a', new Foo(1)],
+            ['b', new Foo(2)],
+        ]);
 
         $this->assertEquals(
             Option::some($hm),
-            $hm->everyMap(fn($x) => $x->value >= 1 ? Option::some($x->value) : Option::none())
+            $hm->everyMap(fn($x) => $x->value->a >= 1 ? Option::some($x->value) : Option::none())
         );
         $this->assertEquals(
             Option::none(),
-            $hm->everyMap(fn($x) => $x->value >= 2 ? Option::some($x->value) : Option::none())
+            $hm->everyMap(fn($x) => $x->value->a >= 2 ? Option::some($x->value) : Option::none())
         );
     }
 

--- a/tests/Runtime/Interfaces/NonEmptyMap/NonEmptyMapOpsTest.php
+++ b/tests/Runtime/Interfaces/NonEmptyMap/NonEmptyMapOpsTest.php
@@ -37,6 +37,20 @@ final class NonEmptyMapOpsTest extends TestCase
         $this->assertTrue($hm->every(fn($entry) => in_array($entry->key, ['a', 'b'])));
     }
 
+    public function testEveryMap(): void
+    {
+        $hm = NonEmptyHashMap::collectPairsUnsafe([['a', 1], ['b', 2]]);
+
+        $this->assertEquals(
+            Option::some($hm),
+            $hm->everyMap(fn($x) => $x->value >= 1 ? Option::some($x->value) : Option::none())
+        );
+        $this->assertEquals(
+            Option::none(),
+            $hm->everyMap(fn($x) => $x->value >= 2 ? Option::some($x->value) : Option::none())
+        );
+    }
+
     public function testFilter(): void
     {
         $hm = NonEmptyHashMap::collectPairsUnsafe([['a', new Foo(1)], ['b', 1], ['c',  new Foo(2)]]);

--- a/tests/Runtime/Interfaces/NonEmptySeq/NonEmptySeqOpsTest.php
+++ b/tests/Runtime/Interfaces/NonEmptySeq/NonEmptySeqOpsTest.php
@@ -99,6 +99,33 @@ final class NonEmptySeqOpsTest extends TestCase
     }
 
     /**
+     * @dataProvider provideTestEveryMapData
+     */
+    public function testEveryMap(NonEmptySeq $seq1, NonEmptySeq $seq2): void
+    {
+        $this->assertEquals(
+            Option::some($seq1),
+            $seq1->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+        $this->assertEquals(
+            Option::none(),
+            $seq2->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+    }
+
+    public function provideTestEveryMapData(): Generator
+    {
+        yield NonEmptyArrayList::class => [
+            NonEmptyArrayList::collectNonEmpty([1, 2, 3]),
+            NonEmptyArrayList::collectNonEmpty([0, 1, 2]),
+        ];
+        yield NonEmptyLinkedList::class => [
+            NonEmptyLinkedList::collectNonEmpty([1, 2, 3]),
+            NonEmptyLinkedList::collectNonEmpty([0, 1, 2]),
+        ];
+    }
+
+    /**
      * @dataProvider provideTestExistsData
      */
     public function testExists(NonEmptySeq $seq): void

--- a/tests/Runtime/Interfaces/NonEmptySet/NonEmptySetOpsTest.php
+++ b/tests/Runtime/Interfaces/NonEmptySet/NonEmptySetOpsTest.php
@@ -49,6 +49,20 @@ final class NonEmptySetOpsTest extends TestCase
         $this->assertFalse(NonEmptyHashSet::collectNonEmpty([new Foo(1), new Bar(2)])->everyOf(Foo::class));
     }
 
+    public function testEveryMap(): void
+    {
+        $hs = NonEmptyHashSet::collectNonEmpty([1, 2, 3]);
+
+        $this->assertEquals(
+            Option::some($hs),
+            $hs->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+        $this->assertEquals(
+            Option::none(),
+            $hs->everyMap(fn($x) => $x >= 2 ? Option::some($x) : Option::none()),
+        );
+    }
+
     public function testExists(): void
     {
         /** @psalm-var NonEmptyHashSet<object|scalar> $hs */

--- a/tests/Runtime/Interfaces/NonEmptySet/NonEmptySetOpsTest.php
+++ b/tests/Runtime/Interfaces/NonEmptySet/NonEmptySetOpsTest.php
@@ -51,15 +51,18 @@ final class NonEmptySetOpsTest extends TestCase
 
     public function testEveryMap(): void
     {
-        $hs = NonEmptyHashSet::collectNonEmpty([1, 2, 3]);
+        $hs = NonEmptyHashSet::collectNonEmpty([
+            new Foo(1),
+            new Foo(2),
+        ]);
 
         $this->assertEquals(
             Option::some($hs),
-            $hs->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+            $hs->everyMap(fn($x) => $x->a >= 1 ? Option::some($x) : Option::none()),
         );
         $this->assertEquals(
             Option::none(),
-            $hs->everyMap(fn($x) => $x >= 2 ? Option::some($x) : Option::none()),
+            $hs->everyMap(fn($x) => $x->a >= 2 ? Option::some($x) : Option::none()),
         );
     }
 

--- a/tests/Runtime/Interfaces/Seq/SeqOpsTest.php
+++ b/tests/Runtime/Interfaces/Seq/SeqOpsTest.php
@@ -99,6 +99,33 @@ final class SeqOpsTest extends TestCase
     }
 
     /**
+     * @dataProvider provideTestEveryMapData
+     */
+    public function testEveryMap(Seq $seq1, Seq $seq2): void
+    {
+        $this->assertEquals(
+            Option::some($seq1),
+            $seq1->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+        $this->assertEquals(
+            Option::none(),
+            $seq2->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+    }
+
+    public function provideTestEveryMapData(): Generator
+    {
+        yield ArrayList::class => [
+            ArrayList::collect([1, 2, 3]),
+            ArrayList::collect([0, 1, 2]),
+        ];
+        yield LinkedList::class => [
+            LinkedList::collect([1, 2, 3]),
+            LinkedList::collect([0, 1, 2]),
+        ];
+    }
+
+    /**
      * @dataProvider provideTestExistsData
      */
     public function testExists(Seq $seq): void

--- a/tests/Runtime/Interfaces/Set/SetOpsTest.php
+++ b/tests/Runtime/Interfaces/Set/SetOpsTest.php
@@ -48,6 +48,20 @@ final class SetOpsTest extends TestCase
         $this->assertFalse(HashSet::collect([new Foo(1), new Bar(2)])->everyOf(Foo::class));
     }
 
+    public function testEveryMap(): void
+    {
+        $hs = HashSet::collect([1, 2, 3]);
+
+        $this->assertEquals(
+            Option::some($hs),
+            $hs->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+        );
+        $this->assertEquals(
+            Option::none(),
+            $hs->everyMap(fn($x) => $x >= 2 ? Option::some($x) : Option::none()),
+        );
+    }
+
     public function testExists(): void
     {
         /** @psalm-var HashSet<object|scalar> $hs */

--- a/tests/Runtime/Interfaces/Set/SetOpsTest.php
+++ b/tests/Runtime/Interfaces/Set/SetOpsTest.php
@@ -50,15 +50,18 @@ final class SetOpsTest extends TestCase
 
     public function testEveryMap(): void
     {
-        $hs = HashSet::collect([1, 2, 3]);
+        $hs = HashSet::collect([
+            new Foo(1),
+            new Foo(2),
+        ]);
 
         $this->assertEquals(
             Option::some($hs),
-            $hs->everyMap(fn($x) => $x >= 1 ? Option::some($x) : Option::none()),
+            $hs->everyMap(fn($x) => $x->a >= 1 ? Option::some($x) : Option::none()),
         );
         $this->assertEquals(
             Option::none(),
-            $hs->everyMap(fn($x) => $x >= 2 ? Option::some($x) : Option::none()),
+            $hs->everyMap(fn($x) => $x->a >= 2 ? Option::some($x) : Option::none()),
         );
     }
 


### PR DESCRIPTION
PR introduces a helpful operation `everyMap`. It allows to perform follow transformations: `Collection<Option<T>>` -> `Option<Collection<T>>`.

The `everyMap` has similar effect as the `filterMap`. So the output type can be different from the input type:

```php
/**
 * @param ArrayList<Arg|VariadicPlaceholder> $args
 * @return Option<ArrayList<Arg>>
 */
function assertAllArgs(ArrayList $args): Option
{
    return $args->everyMap(fn($x) => $x instanceof Arg ? Option::some($x) : Option::none());
}
```

P.S.
After `git clone` and `composer install` I've received latest Psalm version.
Psalm has come with internal changes and it a little affected to the plugin hooks.
I also fixed static errors in plugin hooks.

P.S.S.
Also `filterMap` and `everyMap` has been implemented as functions.