### PR TITLE
Fix Either::flatMap signature

### DIFF
--- a/src/Fp/Functional/Either/Either.php
+++ b/src/Fp/Functional/Either/Either.php
@@ -192,9 +192,10 @@ abstract class Either
      * => Left('error')
      * ```
      *
+     * @psalm-template LO
      * @psalm-template RO
-     * @psalm-param callable(R): Either<L, RO> $callback
-     * @psalm-return Either<L, RO>
+     * @psalm-param callable(R): Either<LO, RO> $callback
+     * @psalm-return Either<LO|L, RO>
      */
     public function flatMap(callable $callback): Either
     {


### PR DESCRIPTION
```php
/**
 * @return Either<int, stdClass>
 */
function doSomething(mixed $_param): Either
{
    throw new RuntimeException('???');
}

/**
 * @return Either<string, stdClass>
 */
function findSomething(): Either
{
    throw new RuntimeException('???');
}

/**
 * @return Either<string|int, stdClass>
 */
function app(): Either
{
    /**
     * ERROR: InvalidScalarArgument
     * at /some-path/run.php:26:19
     *   Argument 1 of Either::flatMap
     *      expects callable(stdClass):Either<string, mixed>
     *      provided impure-Closure(stdClass):Either<int, stdClass> (see https://psalm.dev/012)
     */
    return findSomething()
        ->flatMap(fn($something) => doSomething($something));
}
```