### PR TITLE
Fix php8.4 deprecations

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,17 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-    - name: Cache Composer dependencies
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ github.sha }}
+      - name: Cache Composer dependencies
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ github.sha }}
 
   psalm:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Restore cached composer dependencies
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ github.sha }}
@@ -52,16 +52,16 @@ jobs:
 
       - name: Restore cached composer dependencies
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ github.sha }}
 
       - name: Run test suite
         run: php vendor/bin/phpunit
-
-#      - name: Check PhpUnit coverage percentage
-#        run: php vendor/bin/coverage-check build/logs/clover.xml 85
+      
+      #      - name: Check PhpUnit coverage percentage
+      #        run: php vendor/bin/coverage-check build/logs/clover.xml 85
 
       - name: Upload coverage results to Coveralls
         env:

--- a/src/Fp/Collections/NonEmptySetTerminalOps.php
+++ b/src/Fp/Collections/NonEmptySetTerminalOps.php
@@ -575,7 +575,7 @@ interface NonEmptySetTerminalOps
      *
      * @template TVO
      *
-     * @param callable(TV): Option<TVO> $callback
+     * @param callable(mixed...): Option<TVO> $callback
      * @return Set<TVO>
      */
     public function filterMapN(callable $callback): Set;

--- a/src/Fp/Functions/Callable/Compose.php
+++ b/src/Fp/Functions/Callable/Compose.php
@@ -63,14 +63,14 @@ use function Fp\Collection\tail;
 function compose(
     callable $aToB,
     callable $bToC,
-    callable $cToD = null,
-    callable $dToF = null,
-    callable $fToG = null,
-    callable $gToH = null,
-    callable $hToI = null,
-    callable $iToJ = null,
-    callable $jToK = null,
-    callable $kToL = null,
+    ?callable $cToD = null,
+    ?callable $dToF = null,
+    ?callable $fToG = null,
+    ?callable $gToH = null,
+    ?callable $hToI = null,
+    ?callable $iToJ = null,
+    ?callable $jToK = null,
+    ?callable $kToL = null,
 ): callable
 {
     $callableChain = filterNotNull([$aToB, $bToC, $cToD, $dToF, $fToG, $gToH, $hToI, $iToJ, $jToK, $kToL]);


### PR DESCRIPTION
Updated code to resolve deprecations introduced in PHP 8.4. Adjusted implicitly nullable parameters and other deprecated functionality as per the migration guide.

Reference: [PHP 8.4 Deprecations](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter)